### PR TITLE
War machine pms

### DIFF
--- a/src/common/production_method_groups/kmpmp_01_industry.txt
+++ b/src/common/production_method_groups/kmpmp_01_industry.txt
@@ -7,3 +7,13 @@
 		pm_vacuum_canning
 	}
 }
+pmg_tanks = {
+	texture = "gfx/interface/icons/generic_icons/mixed_icon_refining.dds"
+	production_methods = {
+		pm_no_tank_production
+		pm_tank_production
+		kmpmp_pm_extensive_tank_production
+		kmpmp_pm_focus_tank_production
+		kmpmp_pm_prioritize_tank_production
+	}
+}

--- a/src/common/production_methods/kmpmp_01_industry.txt
+++ b/src/common/production_methods/kmpmp_01_industry.txt
@@ -466,3 +466,84 @@ pm_bolt_action_rifles = {
 		}
 	}
 }
+
+kmpmp_pm_extensive_tank_production = {
+	texture = "gfx/interface/icons/production_method_icons/tanks.dds"
+
+	unlocking_technologies = {
+		mobile_armor
+	}
+
+	building_modifiers = {
+		workforce_scaled = {
+			# input goods
+			goods_input_engines_add = 10
+			goods_input_steel_add = 20
+			goods_input_oil_add = 10
+			goods_output_aeroplanes_add = -10
+
+			# output goods
+			goods_output_tanks_add = 60
+			goods_output_aeroplanes_add = -30
+		}
+
+		level_scaled = {
+			# employment
+			building_employment_engineers_add = 500
+		}
+	}
+}
+
+kmpmp_pm_focus_tank_production = {
+	texture = "gfx/interface/icons/production_method_icons/tanks.dds"
+
+	unlocking_technologies = {
+		mobile_armor
+	}
+
+	building_modifiers = {
+		workforce_scaled = {
+			# input goods
+			goods_input_engines_add = 10
+			goods_input_steel_add = 20
+			goods_input_oil_add = 10
+			goods_output_aeroplanes_add = -10
+
+			# output goods
+			goods_output_tanks_add = 70
+			goods_output_aeroplanes_add = -40
+		}
+
+		level_scaled = {
+			# employment
+			building_employment_engineers_add = 500
+		}
+	}
+}
+
+kmpmp_pm_prioritize_tank_production = {
+	texture = "gfx/interface/icons/production_method_icons/tanks.dds"
+
+	unlocking_technologies = {
+		mobile_armor
+	}
+
+	building_modifiers = {
+		workforce_scaled = {
+			# input goods
+			goods_input_engines_add = 10
+			goods_input_steel_add = 20
+			goods_input_oil_add = 10
+			goods_output_aeroplanes_add = -10
+
+			# output goods
+			goods_output_tanks_add = 80
+			goods_output_aeroplanes_add = -50
+		}
+
+		level_scaled = {
+			# employment
+			building_employment_engineers_add = 500
+		}
+	}
+}

--- a/src/common/production_methods/kmpmp_01_industry.txt
+++ b/src/common/production_methods/kmpmp_01_industry.txt
@@ -537,8 +537,8 @@ kmpmp_pm_prioritize_tank_production = {
 			goods_output_aeroplanes_add = -10
 
 			# output goods
-			goods_output_tanks_add = 80
-			goods_output_aeroplanes_add = -50
+			goods_output_tanks_add = 81
+			goods_output_aeroplanes_add = -51
 		}
 
 		level_scaled = {

--- a/src/localization/english/kmpmp_l_english.yml
+++ b/src/localization/english/kmpmp_l_english.yml
@@ -169,3 +169,6 @@
  kmpmp_ev_persia.1.a:0 "Hooray"
 
  kmpmp_china_buff:0 "China buff"
+ kmpmp_pm_extensive_tank_production:0 "Extensive Tank Production"
+ kmpmp_pm_focus_tank_production:0 "Focus Tank Production"
+ kmpmp_pm_prioritize_tank_production:0 "Prioritize Tank Production"

--- a/src/localization/german/kmpmp_l_german.yml
+++ b/src/localization/german/kmpmp_l_german.yml
@@ -169,3 +169,6 @@
  kmpmp_ev_persia.1.a:0 "Hooray"
 
  kmpmp_china_buff:0 "China buff"
+ kmpmp_pm_extensive_tank_production:0 "Erhöhte Panzer Produktion"
+ kmpmp_pm_focus_tank_production:0 "Fokus auf Panzer Produktion"
+ kmpmp_pm_prioritize_tank_production:0 "Priorisieren der Panzer Produktion"


### PR DESCRIPTION
New PMs (at puple tab)
Extensive Tank Production
+60 Tanks -30Airplanes
Focus Tank Production
+70 Tanks -40
Prioritize Tank production
+80 Tanks -50
ich frag mich wie eiwei aus 80 81 und aus 50 51 machen konnte sind doch nicht nebeneinander sonder am weitesten weg :/